### PR TITLE
Sia sync v2

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -6,10 +6,10 @@ import {
   getAllCredentialsMetadata,
   getCredentialsMetadataByUniqueIds,
   getEncryptedRecord,
-  openSecret,
+  assertionSecretSession,
   savePrivateKey,
-  updateCredentialCounter,
 } from './store';
+import { enqueueUpload } from './sync/uploader';
 import type { SecretPayload } from './store';
 import {
   Account,
@@ -131,9 +131,8 @@ function chooseAlgorithm(
 
 // Load private key from stored credential and prepare it for signing
 async function loadPrivateKey(
-  uniqueId: string,
-): Promise<[CryptoKey, SigningAlgorithm, SecretPayload]> {
-  const secretPayload = await openSecret(uniqueId);
+  secretPayload: SecretPayload,
+): Promise<[CryptoKey, SigningAlgorithm]> {
   const pkcs8 = new Uint8Array(base64UrlDecode(secretPayload.privateKey));
 
   let algorithmParams: EcKeyImportParams | RsaHashedImportParams | Algorithm;
@@ -157,7 +156,7 @@ async function loadPrivateKey(
   }
 
   const privateKey = await subtle.importKey('pkcs8', pkcs8, algorithmParams, false, ['sign']);
-  return [privateKey, signingAlgorithm, secretPayload];
+  return [privateKey, signingAlgorithm];
 }
 
 // Convert buffer to hexadecimal string
@@ -203,7 +202,7 @@ export async function createCredential(
   options: CredentialCreationOptions,
 ): Promise<AttestationResponse> {
   logInfo('[Authenticator] Starting credential creation...');
-  logDebug('[Authenticator] Options', options);
+  logDebug('[Authenticator] Creation options', options);
 
   try {
     if (!options.publicKey) {
@@ -396,50 +395,14 @@ export async function createCredential(
   }
 }
 
-// Sign the challenge using the credential identified by selectedUniqueId
-export async function handleGetAssertion(
+async function buildSignedAssertionResponse(
   options: GetAssertionOptions,
-  selectedUniqueId: string,
+  rpId: string,
+  challengeString: string,
+  secretPayload: SecretPayload,
 ): Promise<AssertionResponse> {
-  logInfo('[Authenticator] Starting assertion handling...');
-  logDebug('[Authenticator] Assertion options', options);
-
-  // Check for the presence of the challenge
-  if (!options.publicKey || !options.publicKey.challenge) {
-    throw new Error('Challenge is missing in the options');
-  }
-
-  // Decode the challenge
-  let challengeBuffer: Uint8Array;
-  let challengeString: string;
-
-  if (typeof options.publicKey.challenge === 'string') {
-    // Challenge as base64url string
-    challengeBuffer = new Uint8Array(toArrayBuffer(options.publicKey.challenge));
-    challengeString = options.publicKey.challenge;
-  } else {
-    // Challenge as binary (ArrayBuffer or Uint8Array)
-    challengeBuffer = new Uint8Array(toArrayBuffer(options.publicKey.challenge));
-    challengeString = base64UrlEncode(challengeBuffer);
-  }
-
-  logDebug('[Authenticator] Challenge buffer (hex)', bufferToHex(challengeBuffer));
-  logDebug('[Authenticator] Challenge string', challengeString);
-
-  // Determine rpId
-  const rpId = options.publicKey.rpId;
-  if (!rpId) {
-    throw new Error('rpId is missing in assertion options');
-  }
-  logDebug('[Authenticator] Using rpId', rpId);
-
-  const allowedUniqueIds = await resolveAllowedUniqueIds(rpId, options.publicKey.allowCredentials);
-  if (allowedUniqueIds && !allowedUniqueIds.has(selectedUniqueId)) {
-    throw new DOMException('Selected credential is not allowed for this request', 'NotAllowedError');
-  }
-
-  // Load private key, algorithm, and secret payload
-  const [privateKey, algorithm, secretPayload] = await loadPrivateKey(selectedUniqueId);
+  // Load private key and signing algorithm
+  const [privateKey, algorithm] = await loadPrivateKey(secretPayload);
 
   logDebug('[Authenticator] Loaded private key', {
     alg: secretPayload.publicKeyAlgorithm,
@@ -533,9 +496,6 @@ export async function handleGetAssertion(
 
   logDebug('[Authenticator] Signature (base64url)', base64UrlEncode(signature));
 
-  // Update credential counter
-  await updateCredentialCounter(selectedUniqueId);
-
   // Construct the response
   const response: AssertionResponse = {
     type: 'public-key',
@@ -551,6 +511,55 @@ export async function handleGetAssertion(
 
   logDebug('[Authenticator] Assertion response', response);
 
+  return response;
+}
+
+// Handle an assertion request and return a signed response for the selected credential.
+export async function handleGetAssertion(
+  options: GetAssertionOptions,
+  selectedUniqueId: string,
+): Promise<AssertionResponse> {
+  logInfo('[Authenticator] Starting assertion handling...');
+  logDebug('[Authenticator] Assertion options', options);
+
+  // Check for the presence of the challenge
+  if (!options.publicKey || !options.publicKey.challenge) {
+    throw new Error('Challenge is missing in the options');
+  }
+
+  // Decode the challenge
+  let challengeBuffer: Uint8Array;
+  let challengeString: string;
+
+  if (typeof options.publicKey.challenge === 'string') {
+    // Challenge as base64url string
+    challengeBuffer = new Uint8Array(toArrayBuffer(options.publicKey.challenge));
+    challengeString = options.publicKey.challenge;
+  } else {
+    // Challenge as binary (ArrayBuffer or Uint8Array)
+    challengeBuffer = new Uint8Array(toArrayBuffer(options.publicKey.challenge));
+    challengeString = base64UrlEncode(challengeBuffer);
+  }
+
+  logDebug('[Authenticator] Challenge buffer (hex)', bufferToHex(challengeBuffer));
+  logDebug('[Authenticator] Challenge string', challengeString);
+
+  // Determine rpId
+  const rpId = options.publicKey.rpId;
+  if (!rpId) {
+    throw new Error('rpId is missing in assertion options');
+  }
+  logDebug('[Authenticator] Using rpId', rpId);
+
+  const allowedUniqueIds = await resolveAllowedUniqueIds(rpId, options.publicKey.allowCredentials);
+  if (allowedUniqueIds && !allowedUniqueIds.has(selectedUniqueId)) {
+    throw new DOMException('Selected credential is not allowed for this request', 'NotAllowedError');
+  }
+
+  const response = await assertionSecretSession(selectedUniqueId, async (secretPayload) =>
+    buildSignedAssertionResponse(options, rpId, challengeString, secretPayload),
+  );
+  void enqueueUpload(selectedUniqueId);
   return response;
 }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -13,6 +13,7 @@ import {
   getEncryptedRecord,
   getSettings,
   handleMessageInBackground,
+  markSyncedIfStillCurrent,
   saveEncryptedRecord,
   getRootKeyIfAvailable,
   setRootKey,
@@ -156,8 +157,10 @@ async function handleUploadToSia(uniqueId: string) {
 
   // If upload successful, update isSynced flag
   if (result.success) {
-    encryptedRecord.isSynced = true;
-    await saveEncryptedRecord(encryptedRecord);
+    const marked = await markSyncedIfStillCurrent(encryptedRecord);
+    if (!marked) {
+      logDebug('[Background] Skipped sync flag update: record changed since upload');
+    }
   }
 
   return result;

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,19 +5,12 @@ import {
 } from './authenticator';
 import { logDebug, logError, logInfo } from './logger';
 import {
-  downloadPasskeyFromRenterd,
-  listPasskeysFromRenterd,
-  uploadPasskeyDirect,
-} from './sia';
-import {
-  getEncryptedRecord,
-  getSettings,
   handleMessageInBackground,
-  markSyncedIfStillCurrent,
-  saveEncryptedRecord,
   getRootKeyIfAvailable,
   setRootKey,
 } from './store';
+import { enqueueUpload } from './sync/uploader';
+import { handleFullSync } from './sync/syncer';
 import {
   BackgroundMessage,
   CredentialCreationOptions,
@@ -144,71 +137,6 @@ function isBackgroundMessage(message: unknown): message is BackgroundMessage {
   );
 }
 
-// Handles the upload of a single passkey to renterd
-async function handleUploadToSia(uniqueId: string) {
-  // Get encrypted record directly from DB
-  const encryptedRecord = await getEncryptedRecord(uniqueId);
-  if (!encryptedRecord) {
-    return { success: false, error: 'Passkey not found' };
-  }
-
-  // Upload encrypted record as-is
-  const result = await uploadPasskeyDirect(encryptedRecord);
-
-  // If upload successful, update isSynced flag
-  if (result.success) {
-    const marked = await markSyncedIfStillCurrent(encryptedRecord);
-    if (!marked) {
-      logDebug('[Background] Skipped sync flag update: record changed since upload');
-    }
-  }
-
-  return result;
-}
-
-// Handles uploading multiple unsynced passkeys to renterd
-async function handleUploadUnsyncedPasskeys(uniqueIds: string[]) {
-  let uploaded = 0,
-    failed = 0;
-
-  for (const uniqueId of uniqueIds) {
-    try {
-      const { success } = await handleUploadToSia(uniqueId);
-      if (success) uploaded++;
-      else failed++;
-    } catch (error: unknown) {
-      logError(`[Background] Upload failed for ${uniqueId}`, error);
-      failed++;
-    }
-  }
-
-  return { success: failed === 0, uploadedCount: uploaded, failedCount: failed };
-}
-
-// Handles syncing passkeys from renterd to the extension
-async function handleSyncFromSia() {
-  const settings = await getSettings();
-  if (!settings) return { success: false, error: 'No renterd settings' };
-
-  const files = await listPasskeysFromRenterd(settings);
-  let synced = 0,
-    failed = 0;
-
-  for (const fileName of files) {
-    try {
-      const encryptedRecord = await downloadPasskeyFromRenterd(fileName, settings);
-
-      // Save encrypted record directly to DB
-      await saveEncryptedRecord(encryptedRecord);
-      synced++;
-    } catch (error: unknown) {
-      logError(`[Background] Sync failed for ${fileName}`, error);
-      failed++;
-    }
-  }
-  return { success: failed === 0, syncedCount: synced, failedCount: failed };
-}
-
 async function handleGetWrappingPublicKey() {
   try {
     if (!wrappingKeyPair) {
@@ -318,15 +246,11 @@ async function router(message: BackgroundMessage): Promise<unknown> {
         );
 
       case 'uploadToSia':
-        if (!message.uniqueId) return { error: 'Missing uniqueId' };
-        return await handleUploadToSia(message.uniqueId);
+        if (!message.uniqueId) return { success: false, error: 'Missing uniqueId' };
+        return await enqueueUpload(message.uniqueId);
 
-      case 'uploadUnsyncedPasskeys':
-        if (!message.uniqueIds) return { error: 'Missing uniqueIds' };
-        return await handleUploadUnsyncedPasskeys(message.uniqueIds);
-
-      case 'syncFromSia':
-        return await handleSyncFromSia();
+      case 'fullSync':
+        return await handleFullSync();
 
       case 'getWrappingPublicKey':
         return await handleGetWrappingPublicKey();

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -7,22 +7,11 @@ import {
   showSettingsForm,
   validateSettings,
 } from './settings';
-import { CredentialMetadata } from './types';
+import type { FullSyncSummary, UploadResult } from './sync/types';
+import type { CredentialMetadata } from './types';
 
 type NotificationType = 'success' | 'error' | 'info' | 'warning';
 type ModalType = 'confirm';
-
-interface SyncUploadResult {
-  uploadedCount: number;
-  failedCount: number;
-  error: boolean;
-}
-interface SyncDownloadResult {
-  syncedCount: number;
-  failedCount: number;
-  empty: boolean;
-  error: boolean;
-}
 
 // Domain Sanitisation
 function sanitizeDomain(domain: string): string {
@@ -125,7 +114,7 @@ function notify(type: NotificationType, title: string, message: string): void {
 
   const root = document.getElementById('root');
   root?.prepend(alert);
-  setTimeout(() => alert.remove(), 3_000);
+  setTimeout(() => alert.remove(), 4_000);
 }
 
 function modal(type: ModalType, title: string, message: string): Promise<boolean> {
@@ -237,7 +226,7 @@ export class Menu {
     document.addEventListener('DOMContentLoaded', () => {
       void this.init().catch((error: unknown) => {
         logError('[Menu] init error', error);
-        notify('error', 'Error', 'Failed to initialize menu');
+        notify('error', 'Error', 'Failed to initialize menu.');
       });
     });
   }
@@ -504,15 +493,20 @@ export class Menu {
       const response = (await browser.runtime.sendMessage({
         type: 'uploadToSia',
         uniqueId: passkey.uniqueId,
-      })) as { success?: boolean; message?: string; error?: string };
-      if (response?.success) {
+      })) as UploadResult;
+      if (response.success) {
         passkey.isSynced = true;
         button.classList.replace('button-green', 'button-sync');
         updateButtonContent(button, icons.check, 'Synced');
-        notify('success', 'Success', response.message ?? 'Uploaded successfully');
+        notify('success', 'Success!', 'Passkey uploaded to Sia.');
         await this.render();
       } else {
-        throw new Error(response?.error ?? 'Upload failed');
+        notify('error', 'Error', response.error);
+        updateButtonContent(
+          button,
+          passkey.isSynced ? icons.check : icons.sia,
+          passkey.isSynced ? 'Synced' : 'Backup to Sia',
+        );
       }
     } catch (error) {
       logError('[Menu] backup error', error);
@@ -540,76 +534,57 @@ export class Menu {
     }
 
     try {
-      const [uploadResult, downloadResult] = await Promise.all([
-        this.uploadUnsynced(),
-        this.downloadNew(),
-      ]);
+      const response = (await browser.runtime.sendMessage({ type: 'fullSync' })) as
+        | FullSyncSummary
+        | { error: string };
 
-      let type: NotificationType;
-      let message: string;
-
-      if (uploadResult.error || downloadResult.error) {
-        type = 'error';
-        message = 'Error syncing Passkeys with renterd server.';
-      } else if (uploadResult.failedCount || downloadResult.failedCount) {
-        type = 'warning';
-        message = 'Some passkeys failed to synchronize.';
-      } else if (downloadResult.empty) {
-        type = 'info';
-        message = 'No new passkeys found on renterd server.';
-      } else {
-        type = 'success';
-        message = `Synchronized ${downloadResult.syncedCount} passkey(s).`;
+      if ('error' in response) {
+        notify('error', 'Error', 'Error syncing Passkeys with renterd server.');
+        await this.render();
+        return;
       }
 
-      notify(type, type.charAt(0).toUpperCase() + type.slice(1), message);
+      const {
+        uploadedCount,
+        downloadedCount,
+        updatedCount,
+        repairedCount,
+        unreadableCount,
+        failedCount,
+      } = response;
+
+      const successDetails: string[] = [];
+      if (uploadedCount) successDetails.push(`${uploadedCount}\u00A0uploaded`);
+      if (downloadedCount) successDetails.push(`${downloadedCount}\u00A0downloaded`);
+      if (updatedCount) successDetails.push(`${updatedCount}\u00A0updated`);
+      if (repairedCount) successDetails.push(`${repairedCount}\u00A0repaired`);
+
+      const issueDetails: string[] = [];
+      if (unreadableCount) issueDetails.push(`${unreadableCount}\u00A0unreadable`);
+      if (failedCount) issueDetails.push(`${failedCount}\u00A0failed`);
+
+      if (issueDetails.length) {
+        const issueMessage = issueDetails.length > 1
+          ? `Sync issues: ${issueDetails.join(', ')}.`
+          : unreadableCount
+            ? `${unreadableCount} passkey(s) could not be read with the current recovery phrase.`
+            : `${failedCount} passkey(s) failed to synchronize.`;
+
+        notify('warning', 'Warning', issueMessage);
+      }
+
+      if (successDetails.length) {
+        notify('success', 'Success!', `Synced passkeys: ${successDetails.join(', ')}.`);
+      } else if (!issueDetails.length) {
+        notify('info', 'Info', 'Everything is up to date.');
+      }
+
       await this.render();
     } catch (error) {
       logError('[Menu] sync error', error);
       notify('error', 'Error', 'Error syncing Passkeys with renterd server.');
     } finally {
       resetSyncButton(button);
-    }
-  }
-
-  private async uploadUnsynced(): Promise<SyncUploadResult> {
-    const all = (await browser.runtime.sendMessage({ type: 'getAllCredentialsMetadata' })) as CredentialMetadata[];
-    const unsynced = all.filter((credential) => !credential.isSynced);
-    if (!unsynced.length) return { uploadedCount: 0, failedCount: 0, error: false };
-
-    try {
-      const uniqueIds = unsynced.map((credential) => credential.uniqueId);
-      const response = (await browser.runtime.sendMessage({
-        type: 'uploadUnsyncedPasskeys',
-        uniqueIds,
-      })) as { uploadedCount?: number; failedCount?: number; success?: boolean };
-      return {
-        uploadedCount: response?.uploadedCount ?? 0,
-        failedCount: response?.failedCount ?? 0,
-        error: !response?.success,
-      };
-    } catch (error) {
-      logError('[Menu] uploadUnsynced error', error);
-      return { uploadedCount: 0, failedCount: unsynced.length, error: true };
-    }
-  }
-
-  private async downloadNew(): Promise<SyncDownloadResult> {
-    try {
-      const response = (await browser.runtime.sendMessage({ type: 'syncFromSia' })) as {
-        syncedCount?: number;
-        failedCount?: number;
-        success?: boolean;
-      };
-      return {
-        syncedCount: response?.syncedCount ?? 0,
-        failedCount: response?.failedCount ?? 0,
-        empty: !response?.syncedCount && !response?.failedCount,
-        error: !response?.success,
-      };
-    } catch (error) {
-      logError('[Menu] downloadNew error', error);
-      return { syncedCount: 0, failedCount: 0, empty: true, error: true };
     }
   }
 }

--- a/src/sia.ts
+++ b/src/sia.ts
@@ -7,8 +7,10 @@ const MIME_OCTET_STREAM = 'application/octet-stream';
 const QUERY_BUCKET = 'bucket';
 const QUERY_MIMETYPE = 'mimetype';
 
-export function fileNameToUniqueId(fileName: string): string {
-  return fileName.replace(/\.passkey$/, '');
+interface RemotePasskeyFile {
+  fileName: string;
+  uniqueId: string;
+  etag: string | null;
 }
 
 function isValidEnvelope(value: unknown): value is EncryptedEnvelope {
@@ -113,18 +115,34 @@ async function httpRequest(
 // Get a list of passkeys from the bucket.
 export async function listPasskeysFromRenterd(
   settings: RenterdSettings,
-): Promise<string[]> {
+): Promise<RemotePasskeyFile[]> {
   logDebug('[Sia] Starting listPasskeysFromRenterd', { settings });
 
   const response = await httpRequest(buildListURL(settings), {
     method: 'GET',
     headers: buildHeaders(settings),
   });
-  const jsonData = (await response.json()) as { objects?: Array<{ key: string }> };
+  const jsonData = (await response.json()) as {
+    objects?: Array<{ key?: unknown; etag?: unknown; eTag?: unknown }>;
+  };
   const objects = jsonData.objects ?? [];
   const passkeyFiles = objects
-    .map((object) => object.key.replace(/^\//, ''))
-    .filter((key) => key.endsWith(PASSKEY_EXTENSION));
+    .filter((object): object is { key: string; etag?: unknown; eTag?: unknown } => typeof object.key === 'string')
+    .map((object) => ({
+      fileName: object.key.replace(/^\//, ''),
+      etag:
+        typeof object.etag === 'string'
+          ? object.etag
+          : typeof object.eTag === 'string'
+            ? object.eTag
+            : null,
+    }))
+    .filter(({ fileName }) => fileName.endsWith(PASSKEY_EXTENSION))
+    .map(({ fileName, etag }) => ({
+      fileName,
+      uniqueId: fileName.replace(/\.passkey$/, ''),
+      etag,
+    }));
 
   logDebug('[Sia] Found passkey files', { count: passkeyFiles.length, files: passkeyFiles });
   return passkeyFiles;

--- a/src/sia.ts
+++ b/src/sia.ts
@@ -112,6 +112,11 @@ async function httpRequest(
   return response;
 }
 
+function normalizeETag(etag: string | null): string | null {
+  if (!etag) return null;
+  return etag.replace(/^W\//, '').replace(/^"|"$/g, '');
+}
+
 // Get a list of passkeys from the bucket.
 export async function listPasskeysFromRenterd(
   settings: RenterdSettings,
@@ -130,12 +135,13 @@ export async function listPasskeysFromRenterd(
     .filter((object): object is { key: string; etag?: unknown; eTag?: unknown } => typeof object.key === 'string')
     .map((object) => ({
       fileName: object.key.replace(/^\//, ''),
-      etag:
+      etag: normalizeETag(
         typeof object.etag === 'string'
           ? object.etag
           : typeof object.eTag === 'string'
             ? object.eTag
             : null,
+      ),
     }))
     .filter(({ fileName }) => fileName.endsWith(PASSKEY_EXTENSION))
     .map(({ fileName, etag }) => ({
@@ -153,16 +159,17 @@ async function uploadPasskeyToRenterd(
   passkeyData: Blob,
   uniqueId: string,
   settings: RenterdSettings,
-): Promise<void> {
+): Promise<string | null> {
   const fileName = `${uniqueId}${PASSKEY_EXTENSION}`;
   logDebug('[Sia] Starting uploadPasskeyToRenterd', { fileName });
 
-  await httpRequest(buildUploadURL(settings, fileName), {
+  const response = await httpRequest(buildUploadURL(settings, fileName), {
     method: 'PUT',
     headers: buildHeaders(settings, MIME_OCTET_STREAM),
     body: passkeyData,
   });
   logDebug('[Sia] Passkey uploaded to renterd', { fileName });
+  return normalizeETag(response.headers.get('ETag'));
 }
 
 // Download a passkey from renterd and return it as EncryptedRecord.
@@ -195,7 +202,7 @@ export async function downloadPasskeyFromRenterd(
 // Upload an encrypted passkey record to renterd.
 export async function uploadPasskeyDirect(
   record: EncryptedRecord,
-): Promise<{ success: true } | { success: false; error: string }> {
+): Promise<{ success: true; etag: string | null } | { success: false; error: string }> {
   try {
     const settings = await getSettings();
     if (!settings) {
@@ -212,11 +219,11 @@ export async function uploadPasskeyDirect(
       type: MIME_OCTET_STREAM,
     });
 
-    await uploadPasskeyToRenterd(passkeyData, record.uniqueId, settings);
+    const etag = await uploadPasskeyToRenterd(passkeyData, record.uniqueId, settings);
     logDebug('[Sia] Encrypted record prepared and uploaded via renterd worker API', {
       uniqueId: record.uniqueId,
     });
-    return { success: true };
+    return { success: true, etag };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     return {

--- a/src/sia.ts
+++ b/src/sia.ts
@@ -101,7 +101,7 @@ async function httpRequest(
     method: options.method ?? 'GET',
     path: requestURL.pathname,
   });
-  const response = await fetch(url, options);
+  const response = await fetch(url, { ...options, cache: 'no-store' });
   logDebug('[Sia] Response status', { status: response.status });
 
   if (!response.ok) {

--- a/src/sia.ts
+++ b/src/sia.ts
@@ -7,6 +7,10 @@ const MIME_OCTET_STREAM = 'application/octet-stream';
 const QUERY_BUCKET = 'bucket';
 const QUERY_MIMETYPE = 'mimetype';
 
+export function fileNameToUniqueId(fileName: string): string {
+  return fileName.replace(/\.passkey$/, '');
+}
+
 function isValidEnvelope(value: unknown): value is EncryptedEnvelope {
   return Boolean(
     value &&
@@ -90,7 +94,11 @@ async function httpRequest(
   url: string,
   options: RequestInit,
 ): Promise<Response> {
-  logDebug('[Sia] Sending request', { url, options });
+  const requestURL = new URL(url);
+  logDebug('[Sia] Sending request', {
+    method: options.method ?? 'GET',
+    path: requestURL.pathname,
+  });
   const response = await fetch(url, options);
   logDebug('[Sia] Response status', { status: response.status });
 
@@ -113,8 +121,6 @@ export async function listPasskeysFromRenterd(
     headers: buildHeaders(settings),
   });
   const jsonData = (await response.json()) as { objects?: Array<{ key: string }> };
-  logDebug('[Sia] Parsed objects list', jsonData);
-
   const objects = jsonData.objects ?? [];
   const passkeyFiles = objects
     .map((object) => object.key.replace(/^\//, ''))
@@ -131,14 +137,14 @@ async function uploadPasskeyToRenterd(
   settings: RenterdSettings,
 ): Promise<void> {
   const fileName = `${uniqueId}${PASSKEY_EXTENSION}`;
-  logDebug('[Sia] Starting uploadPasskeyToRenterd', { fileName, settings });
+  logDebug('[Sia] Starting uploadPasskeyToRenterd', { fileName });
 
   await httpRequest(buildUploadURL(settings, fileName), {
     method: 'PUT',
     headers: buildHeaders(settings, MIME_OCTET_STREAM),
     body: passkeyData,
   });
-  logDebug('[Sia] Binary passkey blob stored on renterd', { fileName });
+  logDebug('[Sia] Passkey uploaded to renterd', { fileName });
 }
 
 // Download a passkey from renterd and return it as EncryptedRecord.
@@ -146,7 +152,7 @@ export async function downloadPasskeyFromRenterd(
   fileName: string,
   settings: RenterdSettings,
 ): Promise<EncryptedRecord> {
-  logDebug('[Sia] Starting downloadPasskeyFromRenterd', { fileName, settings });
+  logDebug('[Sia] Starting downloadPasskeyFromRenterd', { fileName });
 
   const response = await httpRequest(buildObjectURL(settings, fileName), {
     method: 'GET',
@@ -171,33 +177,29 @@ export async function downloadPasskeyFromRenterd(
 // Upload an encrypted passkey record to renterd.
 export async function uploadPasskeyDirect(
   record: EncryptedRecord,
-): Promise<{ success: boolean; message?: string; error?: string }> {
-  const settings = await getSettings();
-  if (!settings) {
-    return {
-      success: false,
-      error: 'Please configure renterd settings first.',
-    };
-  }
-
-  // Clone record and mark as synced.
-  const recordToUpload = { ...record, isSynced: true };
-  const passkeyDataJson = JSON.stringify(recordToUpload, null, 2);
-  const passkeyData = new Blob([passkeyDataJson], {
-    type: MIME_OCTET_STREAM,
-  });
-
+): Promise<{ success: true } | { success: false; error: string }> {
   try {
+    const settings = await getSettings();
+    if (!settings) {
+      return {
+        success: false,
+        error: 'Please configure renterd settings first.',
+      };
+    }
+
+    // Clone record and mark as synced.
+    const recordToUpload = { ...record, isSynced: true };
+    const passkeyDataJson = JSON.stringify(recordToUpload, null, 2);
+    const passkeyData = new Blob([passkeyDataJson], {
+      type: MIME_OCTET_STREAM,
+    });
+
     await uploadPasskeyToRenterd(passkeyData, record.uniqueId, settings);
     logDebug('[Sia] Encrypted record prepared and uploaded via renterd worker API', {
       uniqueId: record.uniqueId,
     });
-    return {
-      success: true,
-      message: 'Passkey successfully backed up to Sia.',
-    };
+    return { success: true };
   } catch (error: unknown) {
-    logError('[Sia] Error uploading encrypted passkey to renterd', error);
     const message = error instanceof Error ? error.message : String(error);
     return {
       success: false,

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,9 +18,15 @@ const counterLocks: Map<string, Promise<void>> = new Map();
 
 // IndexedDB
 const DB_NAME = 'NydiaDB';
-const DB_VERSION = 4;
+const DB_VERSION = 5;
 const PASSKEY_STORE = 'passkeys';
+const ETAGS_STORE = 'etags';
 const SETTINGS_STORE = 'settings';
+
+type PasskeyETag = {
+  uniqueId: string;
+  etag: string;
+};
 
 function setupStores(db: IDBDatabase) {
   if (!db.objectStoreNames.contains(PASSKEY_STORE)) {
@@ -28,6 +34,9 @@ function setupStores(db: IDBDatabase) {
   }
   if (!db.objectStoreNames.contains(SETTINGS_STORE)) {
     db.createObjectStore(SETTINGS_STORE, { keyPath: 'id' });
+  }
+  if (!db.objectStoreNames.contains(ETAGS_STORE)) {
+    db.createObjectStore(ETAGS_STORE, { keyPath: 'uniqueId' });
   }
 }
 
@@ -205,6 +214,42 @@ export async function getSettings(): Promise<RenterdSettings | null> {
       .objectStore(SETTINGS_STORE)
       .get('renterdSettings').onsuccess = (event) =>
         resolve((event.target as IDBRequest<RenterdSettings>).result ?? null);
+  });
+}
+
+export async function getAllPasskeyETags(): Promise<Map<string, string>> {
+  const db = await openDB();
+  const states: PasskeyETag[] = await new Promise((resolve) => {
+    db
+      .transaction(ETAGS_STORE, 'readonly')
+      .objectStore(ETAGS_STORE)
+      .getAll().onsuccess = (event) =>
+        resolve((event.target as IDBRequest<PasskeyETag[]>).result ?? []);
+  });
+
+  return new Map(states.map(({ uniqueId, etag }) => [uniqueId, etag]));
+}
+
+export async function getPasskeyETag(uniqueId: string): Promise<string | null> {
+  const db = await openDB();
+  const state: PasskeyETag | undefined = await new Promise((resolve) => {
+    db
+      .transaction(ETAGS_STORE, 'readonly')
+      .objectStore(ETAGS_STORE)
+      .get(uniqueId).onsuccess = (event) =>
+        resolve((event.target as IDBRequest<PasskeyETag | undefined>).result ?? undefined);
+  });
+
+  return state?.etag ?? null;
+}
+
+export async function savePasskeyETag(uniqueId: string, etag: string): Promise<void> {
+  const db = await openDB();
+  await new Promise<void>((resolve) => {
+    db
+      .transaction(ETAGS_STORE, 'readwrite')
+      .objectStore(ETAGS_STORE)
+      .put({ uniqueId, etag }).onsuccess = () => resolve();
   });
 }
 
@@ -477,8 +522,9 @@ export async function handleMessageInBackground(message: BackgroundMessage): Pro
         if (typeof message.uniqueId !== 'string') return { error: 'Invalid uniqueId' };
         const db = await openDB();
         await new Promise<void>((resolve, reject) => {
-          const transaction = db.transaction(PASSKEY_STORE, 'readwrite');
+          const transaction = db.transaction([PASSKEY_STORE, ETAGS_STORE], 'readwrite');
           transaction.objectStore(PASSKEY_STORE).delete(message.uniqueId!);
+          transaction.objectStore(ETAGS_STORE).delete(message.uniqueId!);
           transaction.oncomplete = () => resolve();
           transaction.onerror = () => reject(transaction.error ?? new Error('Failed to delete credential'));
         });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,4 @@
-import { logDebug, logError, logWarn } from './logger';
-import { uploadPasskeyDirect } from './sia';
+import { logDebug, logError } from './logger';
 import {
   BackgroundMessage,
   CredentialMetadata,
@@ -8,6 +7,7 @@ import {
   RenterdSettings,
   StoredCredential,
 } from './types';
+import type { ReconcileDecision } from './sync/types';
 import { base64UrlDecode, base64UrlEncode } from './utils/base64url';
 
 // Web Crypto API
@@ -167,11 +167,23 @@ export type SecretPayload = {
   counter: number;
 };
 
-export async function openSecret(uniqueId: string): Promise<SecretPayload> {
+export async function isEncryptedRecordReadable(record: EncryptedRecord): Promise<boolean> {
+  try {
+    const [metadataKey, secretKey] = await Promise.all([deriveMetadataKey(), deriveSecretKey()]);
+    await Promise.all([
+      openEnvelope<MetadataPayload>(metadataKey, record.metadata),
+      openEnvelope<SecretPayload>(secretKey, record.secret),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isStoredRecordReadable(uniqueId: string): Promise<boolean> {
   const record = await getEncryptedRecord(uniqueId);
-  if (!record) throw new Error('Credential not found');
-  const secretKey = await deriveSecretKey();
-  return openEnvelope<SecretPayload>(secretKey, record.secret);
+  if (!record) return false;
+  return isEncryptedRecordReadable(record);
 }
 
 // Settings Management
@@ -282,8 +294,19 @@ export async function getEncryptedRecord(
   });
 }
 
+export async function getAllEncryptedRecords(): Promise<EncryptedRecord[]> {
+  const db = await openDB();
+  return new Promise((resolve) => {
+    db
+      .transaction(PASSKEY_STORE, 'readonly')
+      .objectStore(PASSKEY_STORE)
+      .getAll().onsuccess = (event) =>
+        resolve((event.target as IDBRequest<EncryptedRecord[]>).result ?? []);
+  });
+}
+
 // Save encrypted credential directly to DB
-export async function saveEncryptedRecord(record: EncryptedRecord): Promise<void> {
+async function saveEncryptedRecord(record: EncryptedRecord): Promise<void> {
   const db = await openDB();
   await new Promise<void>((resolve) => {
     db
@@ -324,46 +347,79 @@ export async function markSyncedIfStillCurrent(
   });
 }
 
-// counter + Sia sync
-export function updateCredentialCounter(uniqueId: string): Promise<void> {
+export async function reconcileRemoteRecord(
+  remoteRecord: EncryptedRecord,
+): Promise<ReconcileDecision> {
+  const local = await getEncryptedRecord(remoteRecord.uniqueId);
+
+  if (!local) {
+    await saveEncryptedRecord(remoteRecord);
+    return 'new';
+  }
+
+  if (isEncryptedPayloadIdentical(local, remoteRecord)) {
+    if (!local.isSynced) {
+      await markSyncedIfStillCurrent(local);
+    }
+    return 'identical';
+  }
+
+  const secretKey = await deriveSecretKey();
+  const [localSecret, remoteSecret] = await Promise.all([
+    openEnvelope<SecretPayload>(secretKey, local.secret),
+    openEnvelope<SecretPayload>(secretKey, remoteRecord.secret),
+  ]);
+
+  if (remoteSecret.counter > localSecret.counter) {
+    await saveEncryptedRecord(remoteRecord);
+    return 'updated';
+  }
+
+  // Remote is outdated, keep local and mark for re-upload.
+  local.isSynced = false;
+  await saveEncryptedRecord(local);
+  return 'repair';
+}
+
+export async function assertionSecretSession<T>(
+  uniqueId: string,
+  callback: (secretPayload: SecretPayload) => Promise<T>,
+): Promise<T> {
   const pendingLock = counterLocks.get(uniqueId) ?? Promise.resolve();
 
-  const lockPromise = pendingLock.catch(() => undefined).then(async () => {
+  const assertionPromise = pendingLock.catch(() => undefined).then(async () => {
     const record = await getEncryptedRecord(uniqueId);
     if (!record) throw new Error('Credential not found');
 
     const secretKey = await deriveSecretKey();
     const secretPayload = await openEnvelope<SecretPayload>(secretKey, record.secret);
+    const result = await callback(secretPayload);
+
     secretPayload.counter++;
 
     const { credentialId, userHandle, publicKeyAlgorithm, privateKey, counter } = secretPayload;
-    const newSecret = await sealEnvelope(secretKey, { credentialId, userHandle, publicKeyAlgorithm, privateKey, counter });
+    const newSecret = await sealEnvelope(secretKey, {
+      credentialId,
+      userHandle,
+      publicKeyAlgorithm,
+      privateKey,
+      counter,
+    });
     const updated: EncryptedRecord = { ...record, secret: newSecret, isSynced: false };
     await saveEncryptedRecord(updated);
 
-    uploadPasskeyDirect(updated)
-      .then(async (result) => {
-        if (result.success) {
-          const marked = await markSyncedIfStillCurrent(updated);
-          if (!marked) {
-            logWarn('[Store] counter sync skipped: record changed since upload');
-          }
-        } else {
-          logWarn('[Store] counter sync Sia', result.error);
-        }
-      })
-      .catch((error) => {
-        logError('[Store] Error in async upload', error);
-      });
+    return result;
   });
 
-  counterLocks.set(uniqueId, lockPromise);
-  void lockPromise.finally(() => {
-    if (counterLocks.get(uniqueId) === lockPromise) {
+  const trackedLock = assertionPromise.catch(() => undefined).then(() => undefined);
+  counterLocks.set(uniqueId, trackedLock);
+  void trackedLock.finally(() => {
+    if (counterLocks.get(uniqueId) === trackedLock) {
       counterLocks.delete(uniqueId);
     }
   });
-  return lockPromise;
+
+  return assertionPromise;
 }
 
 // Utility Functions
@@ -406,11 +462,6 @@ export async function savePrivateKey(
 export async function handleMessageInBackground(message: BackgroundMessage): Promise<unknown> {
   try {
     switch (message.type) {
-      case 'updateCredentialCounter':
-        if (typeof message.uniqueId !== 'string') return { error: 'Invalid uniqueId' };
-        await updateCredentialCounter(message.uniqueId);
-        return { status: 'ok' };
-
       case 'getAllCredentialsMetadata':
         return getAllCredentialsMetadata();
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -293,11 +293,42 @@ export async function saveEncryptedRecord(record: EncryptedRecord): Promise<void
   });
 }
 
+function isEncryptedPayloadIdentical(a: EncryptedRecord, b: EncryptedRecord): boolean {
+  return (
+    a.metadata.iv === b.metadata.iv &&
+    a.metadata.data === b.metadata.data &&
+    a.secret.iv === b.secret.iv &&
+    a.secret.data === b.secret.data
+  );
+}
+
+export async function markSyncedIfStillCurrent(
+  uploadedRecord: EncryptedRecord,
+): Promise<boolean> {
+  const db = await openDB();
+  return new Promise<boolean>((resolve, reject) => {
+    const transaction = db.transaction(PASSKEY_STORE, 'readwrite');
+    const store = transaction.objectStore(PASSKEY_STORE);
+
+    transaction.onerror = () => reject(transaction.error ?? new Error('Failed to mark synced'));
+
+    store.get(uploadedRecord.uniqueId).onsuccess = (event) => {
+      const current = (event.target as IDBRequest<EncryptedRecord>).result;
+      if (!current || !isEncryptedPayloadIdentical(current, uploadedRecord)) {
+        resolve(false);
+        return;
+      }
+      current.isSynced = true;
+      store.put(current).onsuccess = () => resolve(true);
+    };
+  });
+}
+
 // counter + Sia sync
 export function updateCredentialCounter(uniqueId: string): Promise<void> {
   const pendingLock = counterLocks.get(uniqueId) ?? Promise.resolve();
 
-  const lockPromise = pendingLock.then(async () => {
+  const lockPromise = pendingLock.catch(() => undefined).then(async () => {
     const record = await getEncryptedRecord(uniqueId);
     if (!record) throw new Error('Credential not found');
 
@@ -310,20 +341,28 @@ export function updateCredentialCounter(uniqueId: string): Promise<void> {
     const updated: EncryptedRecord = { ...record, secret: newSecret, isSynced: false };
     await saveEncryptedRecord(updated);
 
-    uploadPasskeyDirect(updated).then(async (result) => {
-      if (result.success) {
-        updated.isSynced = true;
-        await saveEncryptedRecord(updated);
-      } else {
-        logWarn('[Store] counter sync Sia', result.error);
-      }
-    }).catch((error) => {
-      logError('[Store] Error in async upload', error);
-    });
+    uploadPasskeyDirect(updated)
+      .then(async (result) => {
+        if (result.success) {
+          const marked = await markSyncedIfStillCurrent(updated);
+          if (!marked) {
+            logWarn('[Store] counter sync skipped: record changed since upload');
+          }
+        } else {
+          logWarn('[Store] counter sync Sia', result.error);
+        }
+      })
+      .catch((error) => {
+        logError('[Store] Error in async upload', error);
+      });
   });
 
   counterLocks.set(uniqueId, lockPromise);
-  void lockPromise.finally(() => counterLocks.delete(uniqueId));
+  void lockPromise.finally(() => {
+    if (counterLocks.get(uniqueId) === lockPromise) {
+      counterLocks.delete(uniqueId);
+    }
+  });
   return lockPromise;
 }
 

--- a/src/sync/syncer.ts
+++ b/src/sync/syncer.ts
@@ -4,6 +4,7 @@ import {
   listPasskeysFromRenterd,
 } from '../sia';
 import {
+  getAllPasskeyETags,
   getAllEncryptedRecords,
   getSettings,
   isEncryptedRecordReadable,
@@ -27,15 +28,28 @@ export async function handleFullSync(): Promise<FullSyncSummary> {
     failedCount: 0,
   };
 
-  // Phase 1: Download remote passkeys and reconcile with local
+  // Phase 1: Download remote passkeys that need reconciliation with local
   const remotePasskeyFiles = await listPasskeysFromRenterd(settings);
   const remoteListedIds = new Set(remotePasskeyFiles.map(({ uniqueId }) => uniqueId));
+  const cachedETags = await getAllPasskeyETags();
+
+  const initialLocalRecords = await getAllEncryptedRecords();
+  const localById = new Map(initialLocalRecords.map((record) => [record.uniqueId, record]));
   const repairSet = new Set<string>();
 
   const downloadResults = await Promise.allSettled(
-    remotePasskeyFiles.map(async ({ fileName, etag }) => {
+    remotePasskeyFiles.map(async ({ fileName, uniqueId, etag }) => {
+      const shouldDownload =
+        !etag ||
+        cachedETags.get(uniqueId) !== etag ||
+        !localById.has(uniqueId);
+
+      if (!shouldDownload) {
+        return { uniqueId, etag, skippedDownload: true as const };
+      }
+
       const remoteRecord = await downloadPasskeyFromRenterd(fileName, settings);
-      return { remoteRecord, etag };
+      return { remoteRecord, etag, skippedDownload: false as const };
     }),
   );
 
@@ -47,7 +61,24 @@ export async function handleFullSync(): Promise<FullSyncSummary> {
       continue;
     }
 
-    const { remoteRecord, etag } = result.value;
+    const { etag } = result.value;
+
+    if (result.value.skippedDownload) {
+      const localRecord = localById.get(result.value.uniqueId);
+      logDebug('[Syncer] Skipped', { reason: 'etag-unchanged', uniqueId: result.value.uniqueId });
+
+      if (localRecord?.isSynced === false) {
+        repairSet.add(result.value.uniqueId);
+      }
+
+      if (localRecord && !(await isEncryptedRecordReadable(localRecord))) {
+        logDebug('[Syncer] Record unreadable with current root key', { uniqueId: result.value.uniqueId });
+        summary.unreadableCount++;
+      }
+      continue;
+    }
+
+    const { remoteRecord } = result.value;
 
     try {
       const decision: ReconcileDecision = await reconcileRemoteRecord(remoteRecord);
@@ -96,9 +127,9 @@ export async function handleFullSync(): Promise<FullSyncSummary> {
   }
 
   // Phase 2: Collect all passkeys that need upload
+  const currentLocalRecords = await getAllEncryptedRecords();
   const uploadSet = new Set<string>();
-  const localRecords = await getAllEncryptedRecords();
-  for (const local of localRecords) {
+  for (const local of currentLocalRecords) {
     if (!local.isSynced || !remoteListedIds.has(local.uniqueId)) {
       uploadSet.add(local.uniqueId);
     }

--- a/src/sync/syncer.ts
+++ b/src/sync/syncer.ts
@@ -1,7 +1,6 @@
 import { logDebug, logError, logInfo } from '../logger';
 import {
   downloadPasskeyFromRenterd,
-  fileNameToUniqueId,
   listPasskeysFromRenterd,
 } from '../sia';
 import {
@@ -10,6 +9,7 @@ import {
   isEncryptedRecordReadable,
   isStoredRecordReadable,
   reconcileRemoteRecord,
+  savePasskeyETag,
 } from '../store';
 import { enqueueUpload } from './uploader';
 import type { FullSyncSummary, ReconcileDecision } from './types';
@@ -29,22 +29,25 @@ export async function handleFullSync(): Promise<FullSyncSummary> {
 
   // Phase 1: Download remote passkeys and reconcile with local
   const remotePasskeyFiles = await listPasskeysFromRenterd(settings);
-  const remoteListedIds = new Set(remotePasskeyFiles.map(fileNameToUniqueId));
+  const remoteListedIds = new Set(remotePasskeyFiles.map(({ uniqueId }) => uniqueId));
   const repairSet = new Set<string>();
 
   const downloadResults = await Promise.allSettled(
-    remotePasskeyFiles.map((fileName) => downloadPasskeyFromRenterd(fileName, settings)),
+    remotePasskeyFiles.map(async ({ fileName, etag }) => {
+      const remoteRecord = await downloadPasskeyFromRenterd(fileName, settings);
+      return { remoteRecord, etag };
+    }),
   );
 
   for (let i = 0; i < downloadResults.length; i++) {
     const result = downloadResults[i];
     if (result.status === 'rejected') {
-      logError(`[Syncer] Download failed for ${remotePasskeyFiles[i]}`, result.reason);
+      logError(`[Syncer] Download failed for ${remotePasskeyFiles[i].fileName}`, result.reason);
       summary.failedCount++;
       continue;
     }
 
-    const remoteRecord = result.value;
+    const { remoteRecord, etag } = result.value;
 
     try {
       const decision: ReconcileDecision = await reconcileRemoteRecord(remoteRecord);
@@ -67,6 +70,10 @@ export async function handleFullSync(): Promise<FullSyncSummary> {
           void exhaustive;
           throw new Error('Unhandled reconcile decision');
         }
+      }
+
+      if (etag) {
+        await savePasskeyETag(remoteRecord.uniqueId, etag);
       }
 
       const recordToCheck =

--- a/src/sync/syncer.ts
+++ b/src/sync/syncer.ts
@@ -1,0 +1,133 @@
+import { logDebug, logError, logInfo } from '../logger';
+import {
+  downloadPasskeyFromRenterd,
+  fileNameToUniqueId,
+  listPasskeysFromRenterd,
+} from '../sia';
+import {
+  getAllEncryptedRecords,
+  getSettings,
+  isEncryptedRecordReadable,
+  isStoredRecordReadable,
+  reconcileRemoteRecord,
+} from '../store';
+import { enqueueUpload } from './uploader';
+import type { FullSyncSummary, ReconcileDecision } from './types';
+
+export async function handleFullSync(): Promise<FullSyncSummary> {
+  const settings = await getSettings();
+  if (!settings) throw new Error('No renterd settings');
+
+  const summary: FullSyncSummary = {
+    uploadedCount: 0,
+    downloadedCount: 0,
+    updatedCount: 0,
+    repairedCount: 0,
+    unreadableCount: 0,
+    failedCount: 0,
+  };
+
+  // Phase 1: Download remote passkeys and reconcile with local
+  const remotePasskeyFiles = await listPasskeysFromRenterd(settings);
+  const remoteListedIds = new Set(remotePasskeyFiles.map(fileNameToUniqueId));
+  const repairSet = new Set<string>();
+
+  const downloadResults = await Promise.allSettled(
+    remotePasskeyFiles.map((fileName) => downloadPasskeyFromRenterd(fileName, settings)),
+  );
+
+  for (let i = 0; i < downloadResults.length; i++) {
+    const result = downloadResults[i];
+    if (result.status === 'rejected') {
+      logError(`[Syncer] Download failed for ${remotePasskeyFiles[i]}`, result.reason);
+      summary.failedCount++;
+      continue;
+    }
+
+    const remoteRecord = result.value;
+
+    try {
+      const decision: ReconcileDecision = await reconcileRemoteRecord(remoteRecord);
+      logDebug('[Syncer] Reconcile', { decision, uniqueId: remoteRecord.uniqueId });
+
+      switch (decision) {
+        case 'new':
+          summary.downloadedCount++;
+          break;
+        case 'updated':
+          summary.updatedCount++;
+          break;
+        case 'repair':
+          repairSet.add(remoteRecord.uniqueId);
+          break;
+        case 'identical':
+          break;
+        default: {
+          const exhaustive: never = decision;
+          void exhaustive;
+          throw new Error('Unhandled reconcile decision');
+        }
+      }
+
+      const recordToCheck =
+        decision === 'repair'
+          ? null
+          : remoteRecord;
+
+      const isReadable = recordToCheck
+        ? await isEncryptedRecordReadable(recordToCheck)
+        : await isStoredRecordReadable(remoteRecord.uniqueId);
+
+      if (!isReadable) {
+        logDebug('[Syncer] Record unreadable with current root key', { uniqueId: remoteRecord.uniqueId });
+        summary.unreadableCount++;
+      }
+    } catch (error) {
+      logError(`[Syncer] Reconcile failed for ${remoteRecord.uniqueId}`, error);
+      summary.failedCount++;
+    }
+  }
+
+  // Phase 2: Collect all passkeys that need upload
+  const uploadSet = new Set<string>();
+  const localRecords = await getAllEncryptedRecords();
+  for (const local of localRecords) {
+    if (!local.isSynced || !remoteListedIds.has(local.uniqueId)) {
+      uploadSet.add(local.uniqueId);
+    }
+  }
+  // Add repair set to upload set, removing duplicates
+  for (const id of repairSet) {
+    uploadSet.add(id);
+  }
+
+  // Phase 3: Upload passkeys
+  const uploadIds = [...uploadSet];
+  if (uploadIds.length > 0) {
+    const uploadResults = await Promise.all(
+      uploadIds.map((uniqueId) => enqueueUpload(uniqueId)),
+    );
+
+    for (let i = 0; i < uploadResults.length; i++) {
+      const result = uploadResults[i];
+      if (!result.success) {
+        summary.failedCount++;
+      } else if (repairSet.has(uploadIds[i])) {
+        summary.repairedCount++;
+      } else {
+        summary.uploadedCount++;
+      }
+    }
+  }
+
+  const summaryParts: string[] = [];
+  if (summary.uploadedCount) summaryParts.push(`${summary.uploadedCount} uploaded`);
+  if (summary.downloadedCount) summaryParts.push(`${summary.downloadedCount} downloaded`);
+  if (summary.updatedCount) summaryParts.push(`${summary.updatedCount} updated`);
+  if (summary.repairedCount) summaryParts.push(`${summary.repairedCount} repaired`);
+  if (summary.unreadableCount) summaryParts.push(`${summary.unreadableCount} unreadable`);
+  if (summary.failedCount) summaryParts.push(`${summary.failedCount} failed`);
+
+  logInfo(`[Syncer] Full sync complete: ${summaryParts.join(', ') || 'everything is up to date'}.`);
+  return summary;
+}

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -1,0 +1,12 @@
+export type ReconcileDecision = 'new' | 'updated' | 'identical' | 'repair';
+
+export interface FullSyncSummary {
+  uploadedCount: number;
+  downloadedCount: number;
+  updatedCount: number;
+  repairedCount: number;
+  unreadableCount: number;
+  failedCount: number;
+}
+
+export type UploadResult = { success: true } | { success: false; error: string };

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -9,4 +9,4 @@ export interface FullSyncSummary {
   failedCount: number;
 }
 
-export type UploadResult = { success: true } | { success: false; error: string };
+export type UploadResult = { success: true; etag: string | null } | { success: false; error: string };

--- a/src/sync/uploader.ts
+++ b/src/sync/uploader.ts
@@ -1,6 +1,6 @@
 import { logDebug, logError } from '../logger';
 import { uploadPasskeyDirect } from '../sia';
-import { getEncryptedRecord, markSyncedIfStillCurrent } from '../store';
+import { getEncryptedRecord, markSyncedIfStillCurrent, savePasskeyETag } from '../store';
 import type { UploadResult } from './types';
 
 interface UploadEntry {
@@ -21,12 +21,16 @@ async function doUpload(uniqueId: string): Promise<UploadResult> {
     return { success: false, error: result.error };
   }
 
+  if (result.etag) {
+    await savePasskeyETag(uniqueId, result.etag);
+  }
+
   const markedSynced = await markSyncedIfStillCurrent(record);
   if (!markedSynced) {
     logDebug('[Uploader] Skipped sync flag: record changed since upload');
   }
 
-  return { success: true };
+  return { success: true, etag: result.etag };
 }
 
 export function enqueueUpload(uniqueId: string): Promise<UploadResult> {
@@ -38,7 +42,7 @@ export function enqueueUpload(uniqueId: string): Promise<UploadResult> {
 
   const entry: UploadEntry = {
     rerun: false,
-    promise: Promise.resolve<UploadResult>({ success: true }),
+    promise: Promise.resolve<UploadResult>({ success: true, etag: null }),
   };
 
   entry.promise = (async () => {

--- a/src/sync/uploader.ts
+++ b/src/sync/uploader.ts
@@ -1,0 +1,62 @@
+import { logDebug, logError } from '../logger';
+import { uploadPasskeyDirect } from '../sia';
+import { getEncryptedRecord, markSyncedIfStillCurrent } from '../store';
+import type { UploadResult } from './types';
+
+interface UploadEntry {
+  promise: Promise<UploadResult>;
+  rerun: boolean;
+}
+
+const inFlight = new Map<string, UploadEntry>();
+
+async function doUpload(uniqueId: string): Promise<UploadResult> {
+  const record = await getEncryptedRecord(uniqueId);
+  if (!record) return { success: false, error: 'Passkey not found' };
+
+  const result = await uploadPasskeyDirect(record);
+
+  if (!result.success) {
+    logError(`[Uploader] Upload failed for ${uniqueId}`, result.error);
+    return { success: false, error: result.error };
+  }
+
+  const markedSynced = await markSyncedIfStillCurrent(record);
+  if (!markedSynced) {
+    logDebug('[Uploader] Skipped sync flag: record changed since upload');
+  }
+
+  return { success: true };
+}
+
+export function enqueueUpload(uniqueId: string): Promise<UploadResult> {
+  const existing = inFlight.get(uniqueId);
+  if (existing) {
+    existing.rerun = true;
+    return existing.promise;
+  }
+
+  const entry: UploadEntry = {
+    rerun: false,
+    promise: Promise.resolve<UploadResult>({ success: true }),
+  };
+
+  entry.promise = (async () => {
+    try {
+      let result: UploadResult;
+      do {
+        entry.rerun = false;
+        result = await doUpload(uniqueId);
+      } while (entry.rerun);
+      return result;
+    } catch (error) {
+      logError('[Uploader] Upload error', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    } finally {
+      inFlight.delete(uniqueId);
+    }
+  })();
+
+  inFlight.set(uniqueId, entry);
+  return entry.promise;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,6 @@ export interface BackgroundMessage {
   allowCredentialIds?: string[];
   selectedUniqueId?: string;
   uniqueId?: string;
-  uniqueIds?: string[];
   wrappedKey?: number[];
   [key: string]: unknown;
 }


### PR DESCRIPTION
  This PR simplifies passkey synchronization with `renterd` by moving sync orchestration into a shared sync layer and routing uploads through a single per-passkey queue.

  Previously, full sync, manual backup, and assertion-triggered uploads used separate upload paths. That duplicated logic and allowed overlapping uploads for the same passkey.

  The new flow rebuilds full sync around a single entry point, reuses the same per-passkey upload queue across full sync, manual backups, and assertion-triggered uploads, and makes signature `counter` updates and `isSynced` state updates race-safe. It also adds remote `ETag` tracking so unchanged remote passkeys can be skipped safely during sync.